### PR TITLE
Documented the service's credentials being stored in VCAP_SERVICES.

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -37,3 +37,29 @@ Follow the instructions below to create a Redis Labs Enterprise Cluster service 
 1. Click **Redis Labs Enterprise Cluster**.
 1. Choose one of the four preconfigured database plans and click **Select this plan**. For more information about the preconfigured plans, see the [Overview](index.html#overview).
 1. In the **Configure Instance** form, enter an **Instance Name** to identify the service instance in the deployment as well as the database name in RLEC. To override the default parameters and provide additional database configuration parameters, click **Show Advanced Options**. Contact support@redislabs.com for further instructions on using this feature.
+1. Once your service is created and bound to an app, the credentials will be stored in `VCAP_SERVICES` in the following format:
+
+```
+"VCAP_SERVICES": {
+  "redislabs-enterprise-cluster": [
+   {
+    "credentials": {
+     "host": "redis-12345.pcf-rlec.redislabs.com",
+     "ip_list": [
+      "10.0.0.171"
+     ],
+     "password": "some-redis-password",
+     "port": 12345
+    },
+    "label": "redislabs-enterprise-cluster",
+    "name": "my-redis-db",
+    "plan": "ha-redis",
+    "provider": null,
+    "syslog_drain_url": null,
+    "tags": [
+     "redislabs"
+    ]
+   }
+  ]
+}
+```


### PR DESCRIPTION
Hi,

Added docs to reflect the the service's credentials being stored in VCAP_SERVICES, consisting the new 'host' DNS endpoint adde in Redis Labs Enterprise Cluster Tile, ver. 1.6.3 .

Thanks! 
