### PR TITLE
Updated the Product Snapshot and the Release Notes for ver. 1.6.4

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -27,11 +27,11 @@ The following table provides version and version-support information about Redis
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.0</td>
+        <td>v1.6.4</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>June 30, 2016</td>
+        <td>April 26, 2017</td>
     </tr>
     <tr>
         <td>Software component version</td>
@@ -39,11 +39,11 @@ The following table provides version and version-support information about Redis
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>v1.7.x</td>
+        <td>v1.7.x, v1.8.x</td>
     </tr>
     <tr>
         <td>Compatible Elastic Runtime version(s)</td>
-        <td>v1.4.x, v1.5.x, v1.6.x</td>
+        <td>v1.4.x, v1.5.x, v1.6.x, v1.7.x, v1.8.x</td>
     </tr>
     <tr>
         <td>IaaS support</td>
@@ -61,7 +61,7 @@ Please provide any bugs, feature requests, or questions to the [Pivotal Cloud Fo
 
 ## <a id='release-notes'></a>Release Notes
 
-This is the first version of the RP Service Broker.
+Bug fixes and quality improvements.
 
 ## <a id='license'></a>License
 


### PR DESCRIPTION
Hey, this is to make the Product Snapshot and the Release Notes current for the new 1.6.4 version.
Thanks! 